### PR TITLE
[cmd/mdatagen] Fix optional metrics support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
 - `tanzuobservabilityexporter`: Use semantic conventions for status.message (#7126) 
 - `k8sattributesprocessor`: Move `kube` and `observability` packages to `internal` folder (#7159)
 
+## 🧰 Bug fixes 🧰
+
+- `mdatagen`: Fix validation of `enabled` field in metadata.yaml (#7166)
+
 ## v0.42.0
 
 ## 💡 Enhancements 💡

--- a/cmd/mdatagen/loader.go
+++ b/cmd/mdatagen/loader.go
@@ -50,7 +50,7 @@ func (mn attributeName) RenderUnexported() (string, error) {
 
 type metric struct {
 	// Enabled defines whether the metric is enabled by default.
-	Enabled bool `yaml:"enabled" validate:"required"`
+	Enabled *bool `yaml:"enabled" validate:"required"`
 
 	// Description of the metric.
 	Description string `validate:"required,notblank"`

--- a/cmd/mdatagen/loader_test.go
+++ b/cmd/mdatagen/loader_test.go
@@ -47,7 +47,7 @@ func Test_loadMetadata(t *testing.T) {
 						Value:       "state"}},
 				Metrics: map[metricName]metric{
 					"system.cpu.time": {
-						Enabled:               true,
+						Enabled:               (func() *bool { t := true; return &t })(),
 						Description:           "Total CPU seconds broken down by different states.",
 						ExtendedDocumentation: "Additional information on CPU Time can be found [here](https://en.wikipedia.org/wiki/CPU_time).",
 						Unit:                  "s",
@@ -56,9 +56,18 @@ func Test_loadMetadata(t *testing.T) {
 							Aggregated:      Aggregated{Aggregation: "cumulative"},
 							Mono:            Mono{Monotonic: true},
 						},
-						// YmlData: nil,
-						Attributes: []attributeName{"freeFormAttribute", "freeFormAttributeWithValue",
-							"enumAttribute"}}},
+						Attributes: []attributeName{"freeFormAttribute", "freeFormAttributeWithValue", "enumAttribute"},
+					},
+					"system.cpu.utilization": {
+						Enabled:     (func() *bool { f := false; return &f })(),
+						Description: "Percentage of CPU time broken down by different states.",
+						Unit:        "1",
+						Gauge: &gauge{
+							MetricValueType: MetricValueType{pdata.MetricValueTypeDouble},
+						},
+						Attributes: []attributeName{"enumAttribute"},
+					},
+				},
 			},
 		},
 		{

--- a/cmd/mdatagen/testdata/all_options.yaml
+++ b/cmd/mdatagen/testdata/all_options.yaml
@@ -12,6 +12,7 @@ attributes:
     enum: [red, green, blue]
 
 metrics:
+  # A metric enabled by default.
   system.cpu.time:
     enabled: true
     description: Total CPU seconds broken down by different states.
@@ -22,3 +23,12 @@ metrics:
       monotonic: true
       aggregation: cumulative
     attributes: [freeFormAttribute, freeFormAttributeWithValue, enumAttribute]
+
+  # An optional metric.
+  system.cpu.utilization:
+    enabled: false
+    description: Percentage of CPU time broken down by different states.
+    unit: 1
+    gauge:
+      value_type: double
+    attributes: [enumAttribute]


### PR DESCRIPTION
Metrics defined with `enabled: false` flag in metadata.yaml supposed to be optional and not reported by metrics builder by default. There is a bug in metadata.yaml validation which doesn't allow zero value in Enabled field. This change fixes the bug by switching the Enabled field to a pointer type to keep the field required metadata.yaml but not enforce a non-zero value.

**Description:** <Describe what has changed. 
Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.>

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** < Describe what testing was performed and which tests were added.>

**Documentation:** < Describe the documentation added.>