### PR TITLE
[chore] [exporter/signalfx] enable cpu attr in per-core changelog example

### DIFF
--- a/.chloggen/signalfx-cpu-per-core.yaml
+++ b/.chloggen/signalfx-cpu-per-core.yaml
@@ -10,6 +10,10 @@ subtext: |
     hostmetrics:
       scrapers:
         cpu:
+          metrics:
+            system.cpu.time:
+              enabled: true
+              attributes: [cpu, state]
   processors:
     transform/cpu_idle_per_core:
       error_mode: ignore


### PR DESCRIPTION
Follow up to open-telemetry/opentelemetry-collector-contrib#49247.

Updates the `cpu.idle` transform workaround in `.chloggen/signalfx-cpu-per-core.yaml` to explicitly enable `system.cpu.time` with the `cpu` attribute, since that attribute is expected to become opt-in.